### PR TITLE
Change filenameing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/brendanjryan/k8split
 
-go 1.12
+go 1.15
 
 require (
-	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/spf13/cobra v0.0.5
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -44,3 +44,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
-github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 
-	"github.com/iancoleman/strcase"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -66,7 +66,7 @@ var cmd = &cobra.Command{
 			parts = parts[:len(parts)-1]
 		}
 
-		kinds := map[string]int{}
+		names := map[string]int{}
 
 		log.Printf("split file into %d chunks", len(parts))
 
@@ -78,17 +78,29 @@ var cmd = &cobra.Command{
 			}
 
 			// deduce the name of the
-			ks, ok := data["kind"].(string)
+			kind, ok := data["kind"].(string)
 			if !ok {
 				log.Fatalf("no `Kind` field specified for the %d'th document in this file.", i)
 			}
 
-			c, ok := kinds[ks]
-			kinds[ks] = c + 1
+			metadata, ok := data["metadata"].(map[interface{}]interface{})
+			if !ok {
+				log.Fatalf("no `Metadata` field specified for the %d'th document in this file.", i)
+			}
 
-			fName := fmt.Sprintf("%s_%d.yaml", strcase.ToSnake(ks), c)
+			n, ok := metadata["name"].(string)
+			if !ok {
+				log.Fatalf("no `Metadata.name` field specified for the %d'th document in this file.", i)
+			}
+
+			name := fmt.Sprintf("%s-%s", kind, n)
+
+			c, _ := names[name]
+			names[name] = c + 1
+
+			fName := fmt.Sprintf("%s_%d.yaml", strings.ToLower(name), c)
 			if c == 0 {
-				fName = fmt.Sprintf("%s.yaml", strcase.ToSnake(ks))
+				fName = fmt.Sprintf("%s.yaml", strings.ToLower(name))
 			}
 
 			log.Println("Writing file:", fName)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -66,6 +66,11 @@ var cmd = &cobra.Command{
 				log.Fatalf("error reading yaml document %d: %s", i, err)
 			}
 
+			// skip empty documents
+			if len(data) < 1 {
+				continue
+			}
+
 			p, err := yaml.Marshal(data)
 			if err != nil {
 				log.Fatalf("error creating yaml for document %d: %s", i, err)
@@ -77,7 +82,7 @@ var cmd = &cobra.Command{
 				log.Fatalf("no `Kind` field specified for yaml document %d in this file.", i)
 			}
 
-			metadata, ok := data["metadata"].(map[interface{}]interface{})
+			metadata, ok := data["metadata"].(map[string]interface{})
 			if !ok {
 				log.Fatalf("no `Metadata` field specified for yaml document %d in this file.", i)
 			}


### PR DESCRIPTION
Fixes #1 

The PR changes the behavior of k8split so that the the resulting filename includes the name (metadata.name) of the resource of the yaml document. It also removes the snake formatting of the resource kind and uses "-" instead of "_" to separate resource kind from resource name. The intention was to be more in line with the way files are named when using them in helm charts (as a reference see most charts in https://github.com/helm/charts/tree/master/stable).

While I was at it I took the liberty to do some changes under the hood. I updated the code to use yaml.v3 instead of yaml.v2 and from go 1.12 to go 1.15. The spliting of the input file into multiple yaml documents is now more or less left to the actual yaml parser (source: https://stackoverflow.com/questions/53464099/read-multiple-yamls-in-a-file) which frees the code from having to deal with different operating systems. Empty yaml documents are now skipped as well.

